### PR TITLE
pin the terraform azure provider to 1.31

### DIFF
--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -5,7 +5,7 @@ provider "azurerm" {
   tenant_id       = "${var.tenant_id}"
   environment     = "${var.cloud_name}"
 
-  version = "~> 1.22"
+  version = "<= 1.31"
 }
 
 terraform {


### PR DESCRIPTION
The 1.32 azurerm provider gets stuck 

```
Error: Error applying plan:

1 error occurred:
	* module.ops_manager.azurerm_storage_container.ops_manager_storage_container: 1 error occurred:
	* azurerm_storage_container.ops_manager_storage_container: Error creating Container "opsmanagerimage" (Account "5au57afxv4freu65r8hq" / Resource Group "controlplane"): containers.Client#Create: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: error response cannot be parsed: "\ufeff<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.\nRequestId:1898c68b-401c-004b-026d-4c8df3000000\nTime:2019-08-06T15:43:05.1001215Z</Message></Error>" error: invalid character 'ï' looking for beginning of value

```